### PR TITLE
Invalid Solutions

### DIFF
--- a/src/tasks/bo_first_task.erl
+++ b/src/tasks/bo_first_task.erl
@@ -2,31 +2,27 @@
 
 -behaviour(bo_task).
 
--export([describe/0, test/1]).
+-export([description/0, expected_arity/0, timeout/0, tests/0]).
 
--spec describe() -> bo_task:task().
-describe() ->
-  #{ name => ?MODULE
-   , desc => <<"Echo: Return whatever you receive">>
-   , test => fun test/1
-   }.
+-spec description() -> binary().
+description() -> <<"Echo: Return whatever you receive">>.
 
--spec test(fun()) -> bo_task:result().
-test(Fun) when not is_function(Fun, 1) -> {error, invalid_input};
-test(Fun) ->
-  Results =
-    lists:filtermap(
-      fun(Something) ->
-        case Fun(Something) of
-          Something -> false;
-          SomethingElse ->
-            {true, #{ input => Something
-                    , output => SomethingElse
-                    , expected => Something
-                    }}
-        end
-      end, [a, 1, 2.14, #{}]),
-  case Results of
-    [] -> ok;
-    Results -> {failures, Results}
+-spec expected_arity() -> 1.
+expected_arity() -> 1.
+
+-spec timeout() -> 1000.
+timeout() -> 1000.
+
+-spec tests() -> [bo_task:test()].
+tests() -> [build_test(Input) || Input <- [a, 1, 2.14, #{}]].
+
+build_test(Something) ->
+  fun(Fun) ->
+    case Fun(Something) of
+      Something -> ok;
+      SomethingElse -> {error, #{ input => Something
+                                , output => SomethingElse
+                                , expected => Something
+                                }}
+    end
   end.

--- a/src/tasks/bo_task.erl
+++ b/src/tasks/bo_task.erl
@@ -1,12 +1,64 @@
 -module(bo_task).
 
--type result() :: ok | {errors, [term()]}.
+-type result() :: ok | {error, invalid | timeout} | {failures, [term()]}.
 
 -type task() :: #{ name := module()
                  , desc := binary()
-                 , test := fun((fun()) -> result())
+                 , time := pos_integer()
                  }.
 
--export_type([task/0]).
+-type test() :: fun((fun()) -> ok | {error, term()}).
 
--callback describe() -> task().
+-export_type([task/0, result/0, test/0]).
+
+-callback description() -> binary().
+-callback expected_arity() -> non_neg_integer().
+-callback timeout() -> pos_integer().
+-callback tests() -> [test()].
+
+-export([describe/1, test/2]).
+
+-spec describe(module()) -> bo_task:task().
+describe(Task) ->
+  #{ name => Task
+   , desc => Task:description()
+   , time => Task:timeout()
+   }.
+
+-spec test(module(), fun()) -> result().
+test(Task, Fun) ->
+  Arity = Task:expected_arity(),
+  case is_function(Fun, Arity) of
+    false -> {error, invalid};
+    true ->
+      Timeout = Task:timeout(),
+      Tester = start_tester(Task, Fun),
+      receive
+        {Tester, Result} -> Result
+      after Timeout ->
+        true = exit(Tester, kill),
+        {error, timeout}
+      end
+  end.
+
+start_tester(Task, Fun) ->
+  Caller = self(),
+  proc_lib:spawn(
+    fun() ->
+      Results = do_test(Task, Fun),
+      case Results of
+        [] -> Caller ! {self(), ok};
+        Results -> Caller ! {self(), {failures, Results}}
+      end
+    end).
+
+do_test(Task, Fun) ->
+  lists:filtermap(
+    fun(Test) ->
+      try Test(Fun) of
+        ok -> false;
+        {error, Msg} -> {true, Msg}
+      catch
+        _:Exception -> {true, {Exception, erlang:get_stacktrace()}}
+      end
+    end, Task:tests()).

--- a/src/tasks/bo_tasks.erl
+++ b/src/tasks/bo_tasks.erl
@@ -1,7 +1,6 @@
 -module(bo_tasks).
 
 -export([first/0, all/0]).
--export([describe/1]).
 
 -spec first() -> module().
 first() -> application:get_env(beam_olympics, first_task, bo_first_task).
@@ -11,6 +10,3 @@ first() -> application:get_env(beam_olympics, first_task, bo_first_task).
 all() ->
   DefaultList = [bo_first_task],
   application:get_env(beam_olympics, all_tasks, DefaultList).
-
--spec describe(module()) -> bo_task:task().
-describe(Task) -> Task:describe().

--- a/test/bo_invalid_SUITE.erl
+++ b/test/bo_invalid_SUITE.erl
@@ -1,0 +1,90 @@
+-module(bo_invalid_SUITE).
+-author('elbrujohalcon@inaka.net').
+
+-export([all/0]).
+-export([init_per_suite/1, end_per_suite/1]).
+-export([ invalid_input/1
+        , invalid_user/1
+        , test_timeout/1
+        , test_fails/1
+        ]).
+
+-type config() :: proplists:proplist().
+
+-spec all() -> [atom()].
+all() -> [invalid_input, invalid_user, test_timeout, test_fails].
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+  case net_kernel:start(['bo_test@127.0.0.1']) of
+    {ok, _} -> ok;
+    {error, {already_started, _}} -> ok;
+    {error, Error} -> throw(Error)
+  end,
+  {ok, _} = bo:start(),
+  _ = sumo:delete_all(bo_players),
+  {ok, Client} = bo_test_client:start(invalid_suite),
+  {ok, _Task} = bo_test_client:signup(Client, player()),
+  [{client, Client} | Config].
+
+-spec end_per_suite(config()) -> config().
+end_per_suite(Config) ->
+  {client, Client} = lists:keyfind(client, 1, Config),
+  ok = bo_test_client:stop(Client),
+  _ = sumo:delete_all(bo_players),
+  ok = bo:stop(),
+  Config.
+
+-spec invalid_input(config()) -> {comment, string()}.
+invalid_input(Config) ->
+  {client, Client} = lists:keyfind(client, 1, Config),
+
+  ct:comment("Providing something that's not a fun fails"),
+  {error, invalid} = submit(Client, not_a_fun),
+
+  ct:comment("Providing a fun with the wrong arity fails"),
+  {error, invalid} = submit(Client, fun() -> missing_args end),
+
+  {comment, ""}.
+
+-spec invalid_user(config()) -> {comment, string()}.
+invalid_user(Config) ->
+  {client, Client} = lists:keyfind(client, 1, Config),
+
+  ct:comment("Providing a wrong user fails"),
+  {error, notfound} = bo_test_client:submit(Client, <<"wrong">>, solution),
+
+  ct:comment("Providing a wrong node is forbidden"),
+  {ok, Client2} = bo_test_client:start(invalid_node),
+
+  {error, forbidden} =
+    try
+      bo_test_client:submit(Client2, player(), solution)
+    after
+      bo_test_client:stop(Client2)
+    end,
+
+  {comment, ""}.
+
+-spec test_timeout(config()) -> {comment, string()}.
+test_timeout(Config) ->
+  {client, Client} = lists:keyfind(client, 1, Config),
+
+  ct:comment("Providing a function that takes more than expected times out"),
+  {error, timeout} = submit(Client, fun(X) -> receive X -> ok end end),
+
+  {comment, ""}.
+
+-spec test_fails(config()) -> {comment, string()}.
+test_fails(Config) ->
+  {client, Client} = lists:keyfind(client, 1, Config),
+
+  ct:comment("Providing a function that fails the tests returns errors"),
+  {failures, Failures} = submit(Client, fun(X) -> {'not', X} end),
+
+  ct:log("~p", [Failures]),
+
+  {comment, ""}.
+
+player() -> <<"invalid_suite">>.
+submit(Client, Solution) -> bo_test_client:submit(Client, player(), Solution).

--- a/test/bo_task_SUITE.erl
+++ b/test/bo_task_SUITE.erl
@@ -42,7 +42,6 @@ first_task(_Config) ->
     ct:comment("It's a proper task"),
     #{ name := FirstTaskName
      , desc := FirstTaskDesc
-     , test := FirstTaskTest
      } = FirstTask,
 
     ct:comment("Task name is a module that implements bo_task behaviour"),
@@ -50,9 +49,6 @@ first_task(_Config) ->
 
     ct:comment("Desc is a non-empty binary"),
     <<_:1/binary, _/binary>> = FirstTaskDesc,
-
-    ct:comment("Test is a fun with one argument"),
-    true = is_function(FirstTaskTest, 1),
 
     ok
   after


### PR DESCRIPTION
The server should reply with proper warnings in the following scenarios:
- [x] improper input (not a map, not a fun, etc.)
- [x] invalid input (not a registred user, invalid node, etc.)
- [x] timeout (the provided fun fails to run in the expected time)
- [x] tests not passing (the provided fun doesn't respect a test case)